### PR TITLE
refactor: simplify GitHub issue templates for better usability

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-bug-fix.yml
+++ b/.github/ISSUE_TEMPLATE/ai-bug-fix.yml
@@ -4,14 +4,6 @@ title: "[AI Bug Fix] "
 labels: ["bug", "ai-request"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        ## AIバグ修正依頼
-        
-        このテンプレートは、AIにバグの修正を依頼する際に使用してください。
-        問題の詳細を明確に記述することで、AIがより効率的に問題を解決できます。
-        
   - type: input
     id: bug_summary
     attributes:
@@ -25,12 +17,11 @@ body:
     id: bug_description
     attributes:
       label: バグの詳細
-      description: バグの詳細な説明と現象
+      description: 期待される動作と実際の動作
       placeholder: |
-        - 何が起きているか
-        - 期待される動作
-        - 実際の動作
-        - エラーメッセージ（あれば）
+        期待される動作: ...
+        実際の動作: ...
+        エラーメッセージ: ...
     validations:
       required: true
       
@@ -49,8 +40,8 @@ body:
   - type: textarea
     id: affected_files
     attributes:
-      label: 影響を受けるファイル・コンポーネント
-      description: バグが発生していると思われるファイルやコンポーネント
+      label: 影響ファイル
+      description: バグが発生していると思われるファイル
       placeholder: |
         - src/components/UserForm.tsx
         - app/api/auth/route.ts
@@ -61,48 +52,23 @@ body:
     id: priority
     attributes:
       label: 優先度
-      description: バグの優先度を選択してください
       options:
-        - 🔴 高 (サービス停止・重大な機能障害)
-        - 🟠 中 (機能の一部が動作しない)
-        - 🟡 低 (軽微な問題・UI/UXの改善)
+        - 🔴 高 (サービス停止)
+        - 🟠 中 (機能障害)
+        - 🟡 低 (軽微な問題)
     validations:
       required: true
-      
-  - type: textarea
-    id: environment
-    attributes:
-      label: 環境情報
-      description: バグが発生する環境について
-      placeholder: |
-        - ブラウザ: Chrome 120.0
-        - OS: macOS 14.0
-        - デバイス: Desktop
-        - 環境: 開発環境/本番環境
-    validations:
-      required: false
       
   - type: textarea
     id: additional_context
     attributes:
       label: 追加情報
-      description: その他AIが知っておくべき情報
-      placeholder: |
-        - 関連するPRやIssue
-        - 試した解決策
-        - 参考資料
+      description: 環境情報や試した解決策など
+      placeholder: "例: Chrome 120.0, macOS 14.0, 開発環境"
     validations:
       required: false
       
   - type: markdown
     attributes:
       value: |
-        ## AI指示
-        
         **@claude** このバグを調査・修正してください。
-        
-        上記の情報を参考に、以下の手順で対応をお願いします：
-        1. 問題の原因調査
-        2. 修正方法の提案
-        3. コードの修正実装
-        4. テストの実行確認

--- a/.github/ISSUE_TEMPLATE/ai-code-review.yml
+++ b/.github/ISSUE_TEMPLATE/ai-code-review.yml
@@ -4,19 +4,11 @@ title: "[AI Review] "
 labels: ["code-review", "ai-request"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        ## AIコードレビュー依頼
-        
-        このテンプレートは、AIにコードレビューを依頼する際に使用してください。
-        レビューの観点を明確にすることで、AIがより効果的なレビューを行えます。
-        
   - type: input
     id: review_summary
     attributes:
       label: レビュー対象の概要
-      description: レビューしたいコードの簡潔な説明
+      description: レビューしたいコード
       placeholder: "例: 新しいユーザー認証機能の実装"
     validations:
       required: true
@@ -25,7 +17,7 @@ body:
     id: target_files
     attributes:
       label: レビュー対象ファイル
-      description: レビューしたいファイルやコンポーネント
+      description: レビューしたいファイル
       placeholder: |
         - src/components/auth/LoginForm.tsx
         - app/api/auth/login/route.ts
@@ -37,28 +29,23 @@ body:
     id: review_focus
     attributes:
       label: レビュー観点
-      description: 特に注目してほしいレビューポイントを選択してください
+      description: 特に注目してほしいポイント
       options:
         - label: 🐛 バグ・エラーハンドリング
         - label: 🔒 セキュリティ
         - label: ⚡ パフォーマンス
         - label: 📖 可読性・保守性
-        - label: 🏗️ アーキテクチャ・設計
         - label: 🧪 テスタビリティ
-        - label: 🎯 ベストプラクティス
-        - label: ♿ アクセシビリティ
-        - label: 📱 レスポンシブ対応
         - label: 🔧 TypeScript型安全性
         
   - type: dropdown
     id: review_depth
     attributes:
       label: レビューの深さ
-      description: レビューの詳細レベルを選択してください
       options:
-        - 🔍 詳細 (細かい改善点まで指摘)
-        - 📋 標準 (主要な問題点を指摘)
-        - ⚡ 簡潔 (重要な問題のみ指摘)
+        - 🔍 詳細 (細かい改善点まで)
+        - 📋 標準 (主要な問題点)
+        - ⚡ 簡潔 (重要な問題のみ)
     validations:
       required: true
       
@@ -66,37 +53,11 @@ body:
     id: specific_concerns
     attributes:
       label: 特に気になる点
-      description: レビュー時に特に注意してほしい箇所や懸念点
+      description: レビュー時に特に注意してほしい箇所
       placeholder: |
         - パフォーマンスに影響がないか
         - セキュリティホールがないか
         - エラーハンドリングが適切か
-        - テストが不十分な箇所がないか
-    validations:
-      required: false
-      
-  - type: textarea
-    id: context_information
-    attributes:
-      label: コンテキスト情報
-      description: レビューに必要な背景情報
-      placeholder: |
-        - 実装の背景・目的
-        - 技術的制約
-        - 既存システムとの関連
-        - ユーザーストーリー
-    validations:
-      required: false
-      
-  - type: textarea
-    id: testing_status
-    attributes:
-      label: テスト状況
-      description: 現在のテストの実装状況
-      placeholder: |
-        - 実装済みのテスト
-        - 未実装のテスト
-        - テスト方針
     validations:
       required: false
       
@@ -104,12 +65,11 @@ body:
     id: urgency
     attributes:
       label: 緊急度
-      description: レビューの緊急度を選択してください
       options:
-        - 🚨 緊急 (今すぐレビューが必要)
-        - ⏰ 高 (本日中にレビューが必要)
-        - 📅 中 (数日以内にレビューが必要)
-        - 🕰️ 低 (時間があるときにレビュー)
+        - 🚨 緊急 (今すぐ)
+        - ⏰ 高 (本日中)
+        - 📅 中 (数日以内)
+        - 🕰️ 低 (時間があるとき)
     validations:
       required: true
       
@@ -117,24 +77,12 @@ body:
     id: additional_context
     attributes:
       label: 追加情報
-      description: その他AIが知っておくべき情報
-      placeholder: |
-        - 参考資料
-        - 関連するPRやIssue
-        - チームの規約・ガイドライン
-        - 既知の課題
+      description: その他の情報
+      placeholder: "例: 実装の背景、技術的制約、テスト状況など"
     validations:
       required: false
       
   - type: markdown
     attributes:
       value: |
-        ## AI指示
-        
         **@claude** 上記のコードをレビューしてください。
-        
-        以下の観点でレビューをお願いします：
-        1. 選択されたレビュー観点での問題点の指摘
-        2. 改善提案とその理由
-        3. ベストプラクティスとの比較
-        4. 必要に応じて修正コードの提示

--- a/.github/ISSUE_TEMPLATE/ai-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/ai-documentation.yml
@@ -4,19 +4,11 @@ title: "[AI Docs] "
 labels: ["documentation", "ai-request"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        ## AIドキュメント作成・更新依頼
-        
-        このテンプレートは、AIにドキュメントの作成・更新を依頼する際に使用してください。
-        ドキュメントの目的と対象読者を明確にすることで、AIがより適切なドキュメントを作成できます。
-        
   - type: input
     id: doc_summary
     attributes:
       label: ドキュメントの概要
-      description: 作成・更新したいドキュメントの簡潔な説明
+      description: 作成・更新したいドキュメント
       placeholder: "例: 新規ユーザー向けの認証機能の使い方ガイド"
     validations:
       required: true
@@ -24,19 +16,14 @@ body:
   - type: dropdown
     id: doc_type
     attributes:
-      label: ドキュメントの種類
-      description: 作成・更新するドキュメントの種類を選択してください
+      label: ドキュメント種類
       options:
         - 📖 API仕様書
-        - 🚀 セットアップ・インストールガイド
+        - 🚀 セットアップガイド
         - 👥 ユーザーマニュアル
         - 🛠️ 開発者ガイド
-        - 🏗️ アーキテクチャ設計書
-        - 🧪 テストガイド
-        - 🔧 トラブルシューティング
-        - 📋 コード説明・コメント
+        - 📋 コード説明
         - 🎯 機能仕様書
-        - 📈 リリースノート
     validations:
       required: true
       
@@ -44,25 +31,10 @@ body:
     id: doc_action
     attributes:
       label: アクション
-      description: ドキュメントに対する操作を選択してください
       options:
         - ➕ 新規作成
-        - ✏️ 既存ドキュメントの更新
-        - 🔄 既存ドキュメントの刷新
-        - 🗂️ 複数ドキュメントの統合
-    validations:
-      required: true
-      
-  - type: textarea
-    id: target_audience
-    attributes:
-      label: 対象読者
-      description: このドキュメントを読む人について
-      placeholder: |
-        - 開発者（経験レベル）
-        - エンドユーザー
-        - システム管理者
-        - プロジェクトマネージャー
+        - ✏️ 既存更新
+        - 🔄 刷新
     validations:
       required: true
       
@@ -76,29 +48,17 @@ body:
         - 手順・使い方
         - コード例
         - 注意事項
-        - FAQ
-        - 参考資料
     validations:
       required: true
       
   - type: textarea
     id: related_files
     attributes:
-      label: 関連ファイル・コンポーネント
-      description: ドキュメント作成に関連するファイルやコンポーネント
+      label: 関連ファイル
+      description: ドキュメント作成に関連するファイル
       placeholder: |
         - src/components/auth/LoginForm.tsx
-        - app/api/auth/route.ts
         - 既存のREADME.md
-    validations:
-      required: false
-      
-  - type: input
-    id: doc_location
-    attributes:
-      label: ドキュメント配置場所
-      description: ドキュメントを配置する場所（既存の場合は現在の場所）
-      placeholder: "例: docs/auth-guide.md, README.md, src/components/UserForm/README.md"
     validations:
       required: false
       
@@ -106,64 +66,23 @@ body:
     id: detail_level
     attributes:
       label: 詳細レベル
-      description: ドキュメントの詳細度を選択してください
       options:
-        - 📖 詳細 (初心者向け・ステップバイステップ)
-        - 📋 標準 (一般的なレベル)
-        - ⚡ 簡潔 (要点のみ・経験者向け)
+        - 📖 詳細 (初心者向け)
+        - 📋 標準 (一般レベル)
+        - ⚡ 簡潔 (要点のみ)
     validations:
       required: true
-      
-  - type: checkboxes
-    id: doc_features
-    attributes:
-      label: ドキュメント機能
-      description: ドキュメントに含めたい要素を選択してください
-      options:
-        - label: 💻 コード例・サンプル
-        - label: 🖼️ 図・画像
-        - label: 📊 表・一覧
-        - label: ⚠️ 注意事項・警告
-        - label: 💡 ヒント・Tips
-        - label: 🔗 外部リンク
-        - label: 📋 チェックリスト
-        - label: ❓ FAQ
-        
-  - type: textarea
-    id: existing_docs
-    attributes:
-      label: 既存ドキュメント情報
-      description: 更新の場合、現在のドキュメントの問題点や不足している情報
-      placeholder: |
-        - 古い情報が含まれている
-        - 手順が不明確
-        - コード例が動作しない
-        - 新機能の説明が不足
-    validations:
-      required: false
       
   - type: textarea
     id: additional_context
     attributes:
       label: 追加情報
-      description: その他AIが知っておくべき情報
-      placeholder: |
-        - 参考にしたいドキュメント
-        - プロジェクトの方針
-        - ブランディング・トーン
-        - 制約事項
+      description: その他の要件や制約
+      placeholder: "例: 対象読者、配置場所、スタイルガイドなど"
     validations:
       required: false
       
   - type: markdown
     attributes:
       value: |
-        ## AI指示
-        
         **@claude** 上記の要件に基づいてドキュメントを作成・更新してください。
-        
-        以下の手順で実施をお願いします：
-        1. 既存ドキュメントの確認（更新の場合）
-        2. ドキュメント構成の計画
-        3. ドキュメントの作成・更新
-        4. 内容の確認・校正

--- a/.github/ISSUE_TEMPLATE/ai-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/ai-feature-request.yml
@@ -4,19 +4,11 @@ title: "[AI Feature] "
 labels: ["enhancement", "ai-request"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        ## AI機能実装依頼
-        
-        このテンプレートは、AIに新機能の実装を依頼する際に使用してください。
-        要件を明確に記述することで、AIがより正確に実装を行えます。
-        
   - type: input
     id: feature_summary
     attributes:
       label: 機能の概要
-      description: 実装したい機能の簡潔な説明
+      description: 実装したい機能
       placeholder: "例: ユーザープロフィール画像のアップロード機能"
     validations:
       required: true
@@ -41,46 +33,18 @@ body:
       placeholder: |
         - [ ] ユーザーが画像をアップロードできる
         - [ ] アップロードした画像がプロフィールに表示される
-        - [ ] 画像サイズの制限がある
         - [ ] 不正なファイル形式は拒否される
     validations:
       required: true
       
   - type: textarea
-    id: ui_requirements
+    id: affected_files
     attributes:
-      label: UI/UX要件
-      description: ユーザーインターフェースに関する要件
-      placeholder: |
-        - デザイン要件
-        - ユーザー操作フロー
-        - レスポンシブ対応
-        - アクセシビリティ要件
-    validations:
-      required: false
-      
-  - type: textarea
-    id: technical_requirements
-    attributes:
-      label: 技術要件
-      description: 技術的な制約や要件
-      placeholder: |
-        - 使用する技術・ライブラリ
-        - パフォーマンス要件
-        - セキュリティ要件
-        - データベース設計要件
-    validations:
-      required: false
-      
-  - type: textarea
-    id: affected_components
-    attributes:
-      label: 影響を受けるファイル・コンポーネント
-      description: 修正・追加が必要と思われるファイルやコンポーネント
+      label: 関連ファイル
+      description: 修正・追加が必要と思われるファイル
       placeholder: |
         - src/components/UserProfile.tsx
         - app/api/upload/route.ts
-        - prisma/schema.prisma
     validations:
       required: false
       
@@ -88,11 +52,10 @@ body:
     id: priority
     attributes:
       label: 優先度
-      description: 機能の優先度を選択してください
       options:
-        - 🔴 高 (重要な機能・リリース必須)
-        - 🟠 中 (便利な機能・近日実装予定)
-        - 🟡 低 (将来的に実装予定)
+        - 🔴 高 (重要)
+        - 🟠 中 (便利)
+        - 🟡 低 (将来)
     validations:
       required: true
       
@@ -100,24 +63,12 @@ body:
     id: additional_context
     attributes:
       label: 追加情報
-      description: その他AIが知っておくべき情報
-      placeholder: |
-        - 参考資料・デザイン
-        - 競合サービスの例
-        - 関連するIssueやPR
-        - 制約事項
+      description: その他の制約や参考資料
+      placeholder: "例: 参考デザイン、技術制約など"
     validations:
       required: false
       
   - type: markdown
     attributes:
       value: |
-        ## AI指示
-        
         **@claude** この機能を実装してください。
-        
-        上記の要件を参考に、以下の手順で実装をお願いします：
-        1. 実装計画の策定
-        2. 必要なファイル・コンポーネントの作成・修正
-        3. テストの作成・実行
-        4. ドキュメントの更新（必要に応じて）

--- a/.github/ISSUE_TEMPLATE/ai-refactoring.yml
+++ b/.github/ISSUE_TEMPLATE/ai-refactoring.yml
@@ -4,19 +4,11 @@ title: "[AI Refactor] "
 labels: ["refactoring", "ai-request"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        ## AIリファクタリング依頼
-        
-        このテンプレートは、AIにコードのリファクタリングを依頼する際に使用してください。
-        現在の問題点と改善目標を明確にすることで、AIがより効果的なリファクタリングを行えます。
-        
   - type: input
     id: refactoring_summary
     attributes:
-      label: リファクタリングの概要
-      description: リファクタリングしたい内容の簡潔な説明
+      label: 概要
+      description: リファクタリングしたい内容
       placeholder: "例: UserFormコンポーネントの複雑なロジックを分割"
     validations:
       required: true
@@ -25,119 +17,46 @@ body:
     id: current_problems
     attributes:
       label: 現在の問題点
-      description: リファクタリングが必要な理由と現在の問題
+      description: リファクタリングが必要な理由
       placeholder: |
         - コードが複雑で理解しにくい
         - テストが困難
         - パフォーマンスの問題
-        - 重複コードが多い
-        - 責務が混在している
-    validations:
-      required: true
-      
-  - type: textarea
-    id: improvement_goals
-    attributes:
-      label: 改善目標
-      description: リファクタリング後に達成したい状態
-      placeholder: |
-        - コードの可読性向上
-        - テスタビリティの向上
-        - パフォーマンスの改善
-        - 保守性の向上
-        - 拡張性の向上
     validations:
       required: true
       
   - type: textarea
     id: target_files
     attributes:
-      label: 対象ファイル・コンポーネント
-      description: リファクタリング対象のファイルやコンポーネント
+      label: 対象ファイル
+      description: リファクタリング対象のファイル
       placeholder: |
         - src/components/forms/UserForm.tsx
         - src/hooks/useUserData.ts
-        - src/utils/validation.ts
     validations:
       required: true
-      
-  - type: dropdown
-    id: refactoring_type
-    attributes:
-      label: リファクタリングの種類
-      description: 主なリファクタリングの内容を選択してください
-      options:
-        - 🏗️ アーキテクチャの改善
-        - 🧩 コンポーネント分割
-        - 🔄 ロジックの整理
-        - 🎯 パフォーマンス最適化
-        - 🧪 テスタビリティ向上
-        - 📦 依存関係の整理
-        - 🎨 コードスタイルの統一
-    validations:
-      required: true
-      
-  - type: textarea
-    id: constraints
-    attributes:
-      label: 制約・注意事項
-      description: リファクタリング時に考慮すべき制約や注意事項
-      placeholder: |
-        - 既存のAPIとの互換性を保つ
-        - 特定のライブラリを使用する
-        - パフォーマンスを下げない
-        - 既存のテストを壊さない
-    validations:
-      required: false
       
   - type: dropdown
     id: priority
     attributes:
       label: 優先度
-      description: リファクタリングの優先度を選択してください
       options:
-        - 🔴 高 (緊急・重要)
-        - 🟠 中 (重要・計画的に実施)
-        - 🟡 低 (改善・時間があるときに)
+        - 🔴 高 (緊急)
+        - 🟠 中 (計画的)
+        - 🟡 低 (改善)
     validations:
       required: true
-      
-  - type: textarea
-    id: testing_requirements
-    attributes:
-      label: テスト要件
-      description: リファクタリング後のテストに関する要件
-      placeholder: |
-        - 既存のテストを更新
-        - 新しいテストを追加
-        - E2Eテストで動作確認
-        - パフォーマンステスト
-    validations:
-      required: false
       
   - type: textarea
     id: additional_context
     attributes:
       label: 追加情報
-      description: その他AIが知っておくべき情報
-      placeholder: |
-        - 参考資料
-        - 設計ドキュメント
-        - 関連するIssueやPR
-        - 影響を受ける機能
+      description: その他の制約や注意事項
+      placeholder: "例: 既存のAPIとの互換性を保つ"
     validations:
       required: false
       
   - type: markdown
     attributes:
       value: |
-        ## AI指示
-        
         **@claude** このリファクタリングを実施してください。
-        
-        上記の要件を参考に、以下の手順で実施をお願いします：
-        1. 現在のコードの分析
-        2. リファクタリング計画の策定
-        3. 段階的なリファクタリングの実施
-        4. テストの実行・確認
-        5. 変更内容の説明


### PR DESCRIPTION
Simplified all 5 AI issue templates to address Issue #71

## Changes
- Reduced form fields from 7-11 to 5-7 essential fields
- Shortened verbose labels and descriptions
- Simplified dropdown options and removed redundant AI instructions
- Maintained all critical information needed for AI understanding
- Achieved 31-57% reduction in template length across all templates

Closes #71

Generated with [Claude Code](https://claude.ai/code)