### PR TITLE
fix: configure E2E test execution order to prevent dependency failures

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,15 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
+      name: 'setup',
+      testMatch: '**/login/initialRegister.test.ts',
+      fullyParallel: false,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
       name: 'chromium',
+      dependencies: ['setup'],
+      testIgnore: '**/login/initialRegister.test.ts',
       use: { ...devices['Desktop Chrome'] },
     },
 


### PR DESCRIPTION
E2Eテストの実行順序依存問題を修正

### 変更内容
- Playwright設定に`setup`プロジェクトを追加し、`initialRegister.test.ts`を先に実行
- `chromium`プロジェクトが`setup`に依存し、`initialRegister.test.ts`を除外
- ユーザー登録が他のテストより前に実行されることを保証

Fixes #74

Generated with [Claude Code](https://claude.ai/code)